### PR TITLE
Support hapi v21, drop hapi v19, test ESM support

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -12,3 +12,4 @@ jobs:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
     with:
       min-node-version: 14
+      min-hapi-version: 20

--- a/lib/index.js
+++ b/lib/index.js
@@ -308,9 +308,9 @@ internals.setupLogLevelMap = function (logLevelMap) {
 
     for (let i = 0; i < keys.length; ++i) {
         const key = keys[i];
-        const value = mergedMap[key];
+        const value = mergedMap[key] ?? null;
 
-        if (value === undefined || value === null) {
+        if (value === null) {
             // Allow users to unset predefined values.
             continue;
         }
@@ -329,7 +329,7 @@ internals.setupLogLevelMap = function (logLevelMap) {
 exports.plugin = {
     register,
     requirements: {
-        hapi: '>=18.0.0'
+        hapi: '>=20.0.0'
     },
     pkg: require('../package.json')
 };

--- a/lib/pinologger.js
+++ b/lib/pinologger.js
@@ -42,7 +42,7 @@ class Pinologger extends EventEmitter {
     };
 });
 
-internals.stringify = function (level, msg, data, additionalFields = {}) {
+internals.stringify = function (level, msg, data = null, additionalFields = {}) {
 
     let pinoLevel = 30;
     switch (level) {
@@ -72,7 +72,7 @@ internals.stringify = function (level, msg, data, additionalFields = {}) {
         msg
     };
     Hoek.merge(obj, additionalFields);
-    if (data !== undefined && data !== null) {
+    if (data !== null) {
         obj.data = data;
     }
 

--- a/lib/stdlogger.js
+++ b/lib/stdlogger.js
@@ -43,7 +43,7 @@ class Stdlogger extends EventEmitter {
     };
 });
 
-internals.stringify = function (level, msg, data, additionalFields = {}) {
+internals.stringify = function (level, msg, data = null, additionalFields = {}) {
 
     const obj = {
         level,
@@ -52,7 +52,7 @@ internals.stringify = function (level, msg, data, additionalFields = {}) {
     };
     Hoek.merge(obj, additionalFields);
 
-    if (data !== undefined && data !== null) {
+    if (data !== null) {
         obj.data = data;
     }
 

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "^9.1.1",
-    "@hapi/validate": "^1.1.3"
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.0",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "^20.2.2",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
     "@hapi/lab": "^25.0.1"
   },
   "files": [

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Log;
+
+    before(async () => {
+
+        Log = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Log)).to.equal([
+            'Pinologger',
+            'Stdlogger',
+            'default',
+            'plugin'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Support and test on hapi v21, drop support for hapi v19 and below.
 - Test ESM support.
 - Utilize some node v14+ new syntax.

If this looks good, this will be the final addition to log v2.